### PR TITLE
Support sqs from sns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,69 @@
+version: 2
+
+defaults: &defaults
+  docker:
+    - image: circleci/node:10 # https://circleci.com/docs/2.0/circleci-images/
+  working_directory: ~/repo
+jobs:
+  build:
+    <<: *defaults  
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-yarn-lock-{{ checksum "yarn.lock" }}
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/repo/.npmrc
+      - run:
+          name: Install dependencies
+          command: |
+            yarn install
+      - run:
+          name: Test
+          command: |
+            yarn test
+      - run:
+          name: Build
+          command: |
+            yarn build
+      - save_cache:
+          key: v1-yarn-lock-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+
+  deploy-npm:
+    <<: *defaults  
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-yarn-lock-{{ checksum "yarn.lock" }}
+      - run:
+          name: Authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/repo/.npmrc
+      - run:
+          name: Deploy to npm
+          command: |
+            yarn install
+            yarn build
+            yarn publish --patch --message "bumping version - [skip ci]"
+            git push
+            git push --tags
+      - save_cache:
+          key: v1-yarn-lock-{{ checksum "yarn.lock" }}
+          paths:
+            - node_modules
+workflows:
+  version: 2
+  build-and-deploy:
+    jobs:
+      - build:
+          context: development
+      - deploy-npm:
+          context: development
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# a forked version of serverless-offline-sns to support lambda events defined using the sqs-from-sns plugin
+
 # serverless-offline-sns
 A serverless plugin to listen to offline SNS and call lambda fns with events.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # a forked version of serverless-offline-sns to support lambda events defined using the sqs-from-sns plugin
 
+Deployments are currently manual and not run through CI
+
 # serverless-offline-sns
 A serverless plugin to listen to offline SNS and call lambda fns with events.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # a forked version of serverless-offline-sns to support lambda events defined using the sqs-from-sns plugin
 
-Deployments are currently manual and not run through CI
+Fork based off version 0.68.0
 
 # serverless-offline-sns
 A serverless plugin to listen to offline SNS and call lambda fns with events.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uptime.app/serverless-offline-sns",
-  "version": "0.68.0",
+  "version": "0.0.1",
   "description": "Serverless plugin to run a local SNS server and call lambdas with events notifications.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "serverless-offline-sns",
+  "name": "@uptime.app/serverless-offline-sns",
   "version": "0.68.0",
   "description": "Serverless plugin to run a local SNS server and call lambdas with events notifications.",
   "main": "dist/index.js",


### PR DESCRIPTION
In an attempt to run lambda handlers locally rather than having to deploy code or alter tests I have patched `serverless-offline-sns` to support our `sqs-from-sns` plugin